### PR TITLE
fix for multiple wideareas on a single page

### DIFF
--- a/widearea.js
+++ b/widearea.js
@@ -185,6 +185,9 @@
 
     //set fullscreen textarea to small one
     smallTextArea.value = fullscreenTextArea.value;
+    
+    //reset class for targeted text
+    smallTextArea.className = smallTextArea.classname.replace("widearea-fullscreened ", "");
 
     //and then remove the overlay layer
     overlayLayer.parentNode.removeChild(overlayLayer);


### PR DESCRIPTION
You need to remove the class "widearea-fullscreened" from the targeted textarea on closing the full screen text area in order to allow for multiple "wideareas" on a single page.
