### PR TITLE
enable tabbing when in full screen mode

### DIFF
--- a/widearea.js
+++ b/widearea.js
@@ -146,6 +146,13 @@
         //escape key pressed
         _disableFullScreen.call(self);
       }
+      if (e.keyCode == 9) {
+        // tab key pressed
+        e.preventDefault();
+        var s = currentTextArea.selectionStart;
+        currentTextArea.value = currentTextArea.value.substring(0, s) + "\t" + currentTextArea.value.substring(currentTextArea.selectionEnd);
+        currentTextArea.selectionEnd = s + 1;
+      }
     };
     if (window.addEventListener) {
       window.addEventListener('keydown', self._onKeyDown, true);


### PR DESCRIPTION
Would be great to allow tab indent to work while in full screen mode since you don't want to jump focus to the next element while in full screen mode anyway.
