### PR TITLE
make JS compatible with IE 8

### DIFF
--- a/widearea.js
+++ b/widearea.js
@@ -101,8 +101,8 @@
     var currentTextArea = targetTextarea.cloneNode();
 
     //add proper css class names
-    currentTextArea.className = ('widearea-fullscreen '   + targetTextarea.className).trim();
-    targetTextarea.className  = ('widearea-fullscreened ' + targetTextarea.className).trim();
+    currentTextArea.className = ('widearea-fullscreen '   + targetTextarea.className).replace(/^\s+|\s+$/g, "");
+    targetTextarea.className  = ('widearea-fullscreened ' + targetTextarea.className).replace(/^\s+|\s+$/g, "");
 
     var controlPanel = document.createElement('div');
     controlPanel.className = 'widearea-controlPanel';


### PR DESCRIPTION
Hi,

I've been testing widearea in IE 8 and noticed that the only problem was missing `trim` function.

This PR replaces the `trim` function with a regexp, making widearea work in IE 8.
